### PR TITLE
Fix YAMLLoadWarning

### DIFF
--- a/swagger-yaml-to-html.py
+++ b/swagger-yaml-to-html.py
@@ -101,5 +101,5 @@ window.onload = function() {
 </html>
 """
 
-spec = yaml.load(sys.stdin)
+spec = yaml.load(sys.stdin, Loader=yaml.FullLoader)
 sys.stdout.write(TEMPLATE % json.dumps(spec))


### PR DESCRIPTION
Fixing error calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe.